### PR TITLE
Move require statements and add ext: to declare-function invocations

### DIFF
--- a/helm-selector-cider.el
+++ b/helm-selector-cider.el
@@ -33,14 +33,14 @@
 ;;; Code:
 
 (require 'helm-selector)
-(require 'cider nil :noerror)
 
-(declare-function cider "cider")
+(declare-function cider "ext:cider")
 
 ;;;###autoload
 (defun helm-selector-cider ()
   "Helm for `cider' buffers."
   (interactive)
+  (require 'cider)
   (helm-selector
    "CIDER-REPL"
    :predicate (helm-selector-major-modes-predicate 'cider-repl-mode)

--- a/helm-selector-elfeed.el
+++ b/helm-selector-elfeed.el
@@ -33,14 +33,14 @@
 ;;; Code:
 
 (require 'helm-selector)
-(require 'elfeed nil :noerror)
 
-(declare-function elfeed "elfeed")
+(declare-function elfeed "ext:elfeed")
 
 ;;;###autoload
 (defun helm-selector-elfeed ()
   "Helm for `elfeed' buffers."
   (interactive)
+  (require 'elfeed)
   (helm-selector
    "elfeed"
    :predicate (helm-selector-major-modes-predicate 'elfeed-search-mode 'elfeed-show-mode)

--- a/helm-selector-eww.el
+++ b/helm-selector-eww.el
@@ -35,14 +35,14 @@
 (require 'helm-selector)
 (require 'eww)
 (require 'thingatpt)
-(require 'helm-eww nil t)
 
-(declare-function helm-eww "helm-eww")
+(declare-function helm-eww "ext:helm-eww")
 
 ;;;###autoload
 (defun helm-selector-eww ()
   "Helm for `eww' buffers."
   (interactive)
+  (require 'helm-eww)
   (helm-selector
    "eww"
    :predicate (helm-selector-major-modes-predicate 'eww-mode)

--- a/helm-selector-geiser.el
+++ b/helm-selector-geiser.el
@@ -33,15 +33,18 @@
 ;;; Code:
 
 (require 'helm-selector)
-(require 'geiser-impl nil :noerror)
-(require 'geiser-repl nil :noerror)
 
-(declare-function geiser-repl--repl-name "geiser-repl")
+(declare-function geiser-repl--repl-name "ext:geiser-repl")
+(declare-function run-geiser "ext:geiser-repl")
+
+(defvar geiser-repl-buffer-name-function)
 
 ;;;###autoload
 (defun helm-selector-geiser ()
   "Helm for `geiser' buffers."
   (interactive)
+  (require 'geiser-impl)
+  (require 'geiser-repl)
   (helm-selector
    "Geiser-REPL"
    :predicate (helm-selector-major-modes-predicate 'geiser-repl-mode)

--- a/helm-selector-mu4e.el
+++ b/helm-selector-mu4e.el
@@ -33,15 +33,15 @@
 ;;; Code:
 
 (require 'helm-selector)
-(require 'mu4e nil :noerror)
 
-(declare-function mu4e "mu4e")
-(declare-function mu4e-conversation--buffer-p  "mu4e-conversation")
+(declare-function mu4e "ext:mu4e")
+(declare-function mu4e-conversation--buffer-p  "ext:mu4e-conversation")
 
 ;;;###autoload
 (defun helm-selector-mu4e ()
   "Helm for `mu4e' buffers."
   (interactive)
+  (require 'mu4e)
   (helm-selector
    "mu4e"
    :predicate (lambda (buffer)

--- a/helm-selector-notmuch.el
+++ b/helm-selector-notmuch.el
@@ -33,15 +33,15 @@
 ;;; Code:
 
 (require 'helm-selector)
-(require 'notmuch nil :noerror)
 
-(declare-function notmuch-interesting-buffer "notmuch")
-(declare-function notmuch-hello "notmuch-hello")
+(declare-function notmuch-interesting-buffer "ext:notmuch")
+(declare-function notmuch-hello "ext:notmuch-hello")
 
 ;;;###autoload
 (defun helm-selector-notmuch ()
   "Helm for `notmuch' buffers."
   (interactive)
+  (require 'notmuch)
   (helm-selector
    "notmuch"
    :predicate #'notmuch-interesting-buffer

--- a/helm-selector-org.el
+++ b/helm-selector-org.el
@@ -36,6 +36,8 @@
 (require 'subr-x)
 (require 'org)
 
+(defvar org-agenda-files)
+
 ;;;###autoload
 (defun helm-selector-org ()
   "Helm for `org' buffers."

--- a/helm-selector-org.el
+++ b/helm-selector-org.el
@@ -32,8 +32,10 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'subr-x))
+
 (require 'helm-selector)
-(require 'subr-x)
 (require 'org)
 
 (defvar org-agenda-files)

--- a/helm-selector-slime.el
+++ b/helm-selector-slime.el
@@ -33,17 +33,17 @@
 ;;; Code:
 
 (require 'helm-selector)
-(require 'slime nil :noerror)
-(require 'helm-slime nil :noerror)
 
-(declare-function slime "slime")
-(declare-function slime-output-buffer "slime")
-(declare-function helm-slime-mini "helm-slime")
+(declare-function slime "ext:slime")
+(declare-function slime-output-buffer "ext:slime")
+(declare-function helm-slime-mini "ext:helm-slime")
 
 ;;;###autoload
 (defun helm-selector-slime ()
   "Helm for `slime' buffers."
   (interactive)
+  (require 'slime)
+  (require 'helm-slime)
   (helm-selector
    "SLIME-REPL"
    :predicate (lambda (buffer)

--- a/helm-selector-sly.el
+++ b/helm-selector-sly.el
@@ -33,18 +33,18 @@
 ;;; Code:
 
 (require 'helm-selector)
-(require 'sly nil :noerror)
-(require 'helm-sly nil :noerror)
 
-(declare-function sly "sly")
-(declare-function sly-current-connection "sly")
-(declare-function sly-mrepl--find-buffer "sly-mrepl")
-(declare-function helm-sly-mini "helm-sly")
+(declare-function sly "ext:sly")
+(declare-function sly-current-connection "ext:sly")
+(declare-function sly-mrepl--find-buffer "ext:sly-mrepl")
+(declare-function helm-sly-mini "ext:helm-sly")
 
 ;;;###autoload
 (defun helm-selector-sly ()
   "Helm for `sly' buffers."
   (interactive)
+  (require 'sly)
+  (require 'helm-sly)
   (helm-selector
    "SLY-REPL"
    :predicate (lambda (buffer)


### PR DESCRIPTION
For add-on packages, we move the `require` statements inside the `defun`s
~so that someone who installs those packages only after having
installed `helm-selector` will not encounter problems.~ People who don't
use those packages at all remain unaffected.

EDIT: now that I think about it, keeping the `require`s in their original places shouldn't cause those kinds of problems. But I often see this in other packages, for example https://github.com/abo-abo/swiper/blob/7e4c56776f811f78b8eb95210156f8fbbdba67e7/counsel.el#L142. It might be the case that this guards against something I'm not aware of.

Per the documentation for declare-function, we add `ext:` to signal
that the packages are not included with base Emacs.

Also use `eval-when-compile` for `subr-x`.